### PR TITLE
Remove unnecessary classname in Vocab

### DIFF
--- a/app/views/shared/_add_etd_vocabulary.html.erb
+++ b/app/views/shared/_add_etd_vocabulary.html.erb
@@ -1,5 +1,5 @@
 <div class="btn-group add-content">
-  <a class="btn btn-primary dropdown-toggle user-display-name" data-toggle="dropdown" href="#">
+  <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
     Vocab
     <span class="caret"></span>
   </a>


### PR DESCRIPTION
Unnessary classname in Vocab created a bug
i.e., text 'Vocab' appended to the name
in the creator field when selected "Myself" from the
delegater field