### PR TITLE
Repo man

### DIFF
--- a/app/controllers/repo_managers_controller.rb
+++ b/app/controllers/repo_managers_controller.rb
@@ -2,11 +2,10 @@ class RepoManagersController < ApplicationController
   with_themed_layout '1_column'
 
   def edit
-    @repo_manager = RepoManager.where(username: current_user.user_key).first
+    @repo_manager = RepoManager.find_by!(username: current_user.user_key)
   end
 
   def update
-    puts "Repo Params: #{params.inspect}"
     @repo_manager = RepoManager.find(params[:id])
     @repo_manager.active = params[:repo_manager][:active]
     @repo_manager.save

--- a/app/controllers/repo_managers_controller.rb
+++ b/app/controllers/repo_managers_controller.rb
@@ -1,0 +1,15 @@
+class RepoManagersController < ApplicationController
+  with_themed_layout '1_column'
+
+  def edit
+    @repo_manager = RepoManager.where(username: current_user.user_key).first
+  end
+
+  def update
+    puts "Repo Params: #{params.inspect}"
+    @repo_manager = RepoManager.find(params[:id])
+    @repo_manager.active = params[:repo_manager][:active]
+    @repo_manager.save
+    redirect_to root_path
+  end
+end

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -24,11 +24,15 @@ module Curate
       end
 
       def manager?
+        is_user_a_manager? && load_manager.active?
+      end
+
+      def is_user_a_manager?
         manager_usernames.include?(user_key)
       end
 
       def manager_usernames
-        @manager_usernames ||= load_managers
+        @manager_usernames ||= RepoManager.usernames
       end
 
       def name
@@ -41,17 +45,9 @@ module Curate
 
       private
 
-        def load_managers
-          manager_config = "#{::Rails.root}/config/manager_usernames.yml"
-          if File.exist?(manager_config)
-            content = IO.read(manager_config)
-            YAML.load(ERB.new(content).result).fetch(Rails.env).
-              fetch('manager_usernames')
-          else
-            logger.warn "Unable to find managers file: #{manager_config}"
-            []
-          end
-        end
+      def load_manager
+        RepoManager.where(username: user_key).first
+      end
     end
   end
 end

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -24,15 +24,12 @@ module Curate
       end
 
       def manager?
-        repository_manager? && load_manager.active?
+        return false unless repository_manager_record.present?
+        repository_manager_record.active?
       end
 
       def repository_manager?
-        manager_usernames.include?(user_key)
-      end
-
-      def manager_usernames
-        @manager_usernames ||= RepoManager.usernames
+        repository_manager_record.present?
       end
 
       def name
@@ -45,8 +42,8 @@ module Curate
 
       private
 
-      def load_manager
-        RepoManager.where(username: user_key).first
+      def repository_manager_record
+        RepoManager.find_by(username: user_key)
       end
     end
   end

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -24,10 +24,10 @@ module Curate
       end
 
       def manager?
-        is_user_a_manager? && load_manager.active?
+        repository_manager? && load_manager.active?
       end
 
-      def is_user_a_manager?
+      def repository_manager?
         manager_usernames.include?(user_key)
       end
 

--- a/app/models/repo_manager.rb
+++ b/app/models/repo_manager.rb
@@ -1,11 +1,5 @@
 class RepoManager < ActiveRecord::Base
-  validates_uniqueness_of :username
-
   def self.usernames
-    RepoManager.all.collect{|manager| manager.username }
-  end
-
-  def active?
-    self.active == true
+    RepoManager.pluck(:username)
   end
 end

--- a/app/models/repo_manager.rb
+++ b/app/models/repo_manager.rb
@@ -1,0 +1,11 @@
+class RepoManager < ActiveRecord::Base
+  validates_uniqueness_of :username
+
+  def self.usernames
+    RepoManager.all.collect{|manager| manager.username }
+  end
+
+  def active?
+    self.active == true
+  end
+end

--- a/app/views/repo_managers/edit.html.erb
+++ b/app/views/repo_managers/edit.html.erb
@@ -1,0 +1,20 @@
+<fieldset>
+  <legend> Repository Manager </legend>
+  <%= simple_form_for @repo_manager do |f| %>
+    <ul style="text-decoration: none">
+      <li><strong>Account Name: </strong><%= current_user.name %></li>
+      <li><strong>NetID: </strong><%= current_user.user_key %></li>
+      <li><strong>Repository Permission Level: </strong><br/>
+        <% {"All Permissions" => true, "Restricted Permissions" => false}.each do |key, value| %>
+          <div class="radio">
+            <label>
+              <%= f.radio_button(:active, value) %>
+              <%= key %>
+            </label>
+          </div>
+        <% end %>
+      </li>
+    </ul>
+    <%= f.submit class: 'btn btn-primary' %>
+  <% end %>
+</fieldset>

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -11,6 +11,9 @@
     <% if current_user.repository_noid? %>
     <li><%= link_to 'My Delegates',     person_depositors_path(current_user.repository_noid),                  class: 'my-proxies',     role: 'menuitem' %></li>
     <% end %>
+    <% if current_user.is_user_a_manager? %>
+      <li><%= link_to 'RepoManager Permissions', edit_repo_manager_path(current_user.repository_noid),            class: 'repo_managers',     role: 'menuitem' %></li>
+    <% end %>
     <li class="divider"></li>
     <li><%= link_to 'Log Out',        destroy_user_session_path,                                             class: 'log-out',        role: 'menuitem' %></li>
   </ul>

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -11,7 +11,7 @@
     <% if current_user.repository_noid? %>
     <li><%= link_to 'My Delegates',     person_depositors_path(current_user.repository_noid),                  class: 'my-proxies',     role: 'menuitem' %></li>
     <% end %>
-    <% if current_user.is_user_a_manager? %>
+    <% if current_user.repository_manager? %>
       <li><%= link_to 'RepoManager Permissions', edit_repo_manager_path(current_user.repository_noid),            class: 'repo_managers',     role: 'menuitem' %></li>
     <% end %>
     <li class="divider"></li>

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -12,10 +12,9 @@
     <li><%= link_to 'My Delegates',     person_depositors_path(current_user.repository_noid),                  class: 'my-proxies',     role: 'menuitem' %></li>
     <% end %>
     <% if current_user.repository_manager? %>
-      <li><%= link_to 'RepoManager Permissions', edit_repo_manager_path(current_user.repository_noid),            class: 'repo_managers',     role: 'menuitem' %></li>
+      <li><%= link_to 'RepoManager Permissions', edit_repo_manager_path,            class: 'repo_managers',     role: 'menuitem' %></li>
     <% end %>
     <li class="divider"></li>
     <li><%= link_to 'Log Out',        destroy_user_session_path,                                             class: 'log-out',        role: 'menuitem' %></li>
   </ul>
 </div>
-

--- a/db/migrate/20150216123456_create_repo_managers.rb
+++ b/db/migrate/20150216123456_create_repo_managers.rb
@@ -1,0 +1,15 @@
+class CreateRepoManagers < ActiveRecord::Migration
+  def change
+    create_table :repo_managers do |t|
+      t.string :username
+      t.boolean :active
+      t.timestamps
+    end
+
+    add_index :repo_managers, :username
+  end
+
+  def self.down
+    drop_table :repo_managers
+  end
+end

--- a/db/migrate/20150216123456_create_repo_managers.rb
+++ b/db/migrate/20150216123456_create_repo_managers.rb
@@ -6,7 +6,7 @@ class CreateRepoManagers < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :repo_managers, :username
+    add_index :repo_managers, :username, unique: true
   end
 
   def self.down

--- a/lib/curate/rails/routes.rb
+++ b/lib/curate/rails/routes.rb
@@ -62,7 +62,7 @@ module ActionDispatch::Routing
       namespace :hydramata do
         resources 'groups'
       end
-
+      resource :repo_manager, only: [:edit, :update]
     end
   end
 end

--- a/spec/abilities/generic_file_abilities_spec.rb
+++ b/spec/abilities/generic_file_abilities_spec.rb
@@ -31,7 +31,7 @@ describe "User" do
 
       describe 'as a repository manager' do
         let(:email) { 'manager@example.com' }
-        let(:manager_user) { FactoryGirl.create(:user, email: email) }
+        let(:manager_user) { FactoryGirl.create(:repository_manager_user, email: email) }
         let(:creating_user) { user }
         let(:current_user) { manager_user }
         it {

--- a/spec/abilities/generic_work_abilities_spec.rb
+++ b/spec/abilities/generic_work_abilities_spec.rb
@@ -37,7 +37,7 @@ describe "User" do
 
       describe 'as a repository manager' do
         let(:email) { 'manager@example.com' }
-        let(:manager_user) { FactoryGirl.create(:user, email: email) }
+        let(:manager_user) { FactoryGirl.create(:repository_manager_user, email: email) }
         let(:creating_user) { user }
         let(:current_user) { manager_user }
         it {

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -50,7 +50,7 @@ describe CatalogController do
   describe "when logged in as a repository manager" do
     let(:creating_user) { FactoryGirl.create(:user) }
     let(:email) { 'manager@example.com' }
-    let(:manager_user) { FactoryGirl.create(:user, email: email) }
+    let(:manager_user) { FactoryGirl.create(:repository_manager_user, email: email) }
     let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     let!(:work1) {
       FactoryGirl.create_curation_concern(:generic_work, creating_user, { visibility: visibility })

--- a/spec/curate/internal/factories.rb
+++ b/spec/curate/internal/factories.rb
@@ -11,6 +11,12 @@ FactoryGirl.define do
     sign_in_count 20
   end
 
+  factory :repository_manager_user, parent: :user do
+    after(:create) do |user, evaluator|
+      RepoManager.create!(username: user.user_key, active: true)
+    end
+  end
+
   factory :account do
     user { FactoryGirl.build(:user) }
     sequence(:email) {|n| "email-#{srand}@test.com" }
@@ -19,6 +25,11 @@ FactoryGirl.define do
     }
     after(:create) do |account, evaluator|
       account.save
+    end
+  end
+  factory :repository_manager_account, parent: :account do
+    after(:create) do |account, evaluator|
+      RepoManager.create!(username: account.user.user_key, active: true)
     end
   end
 end

--- a/spec/features/manager_profile_workflow_spec.rb
+++ b/spec/features/manager_profile_workflow_spec.rb
@@ -4,7 +4,7 @@ describe 'manager profile workflow', FeatureSupport.options do
 
   describe 'editing other user\'s profile as a manager' do
     let(:manager_email) { 'manager@example.com' }
-    let(:manager_account) { FactoryGirl.create(:account, email: manager_email) }
+    let(:manager_account) { FactoryGirl.create(:repository_manager_account, email: manager_email) }
     let(:manager_user) { manager_account.user }
     let(:account) { FactoryGirl.create(:account) }
     let(:user) { account.user }

--- a/spec/internal/db/migrate/20151012170335_create_repo_managers.curate_engine.rb
+++ b/spec/internal/db/migrate/20151012170335_create_repo_managers.curate_engine.rb
@@ -1,0 +1,16 @@
+# This migration comes from curate_engine (originally 20150216123456)
+class CreateRepoManagers < ActiveRecord::Migration
+  def change
+    create_table :repo_managers do |t|
+      t.string :username
+      t.boolean :active
+      t.timestamps
+    end
+
+    add_index :repo_managers, :username, unique: true
+  end
+
+  def self.down
+    drop_table :repo_managers
+  end
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806134047) do
+ActiveRecord::Schema.define(version: 20151012170335) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",     null: false
@@ -150,6 +150,15 @@ ActiveRecord::Schema.define(version: 20150806134047) do
   end
 
   add_index "receipts", ["notification_id"], name: "index_receipts_on_notification_id"
+
+  create_table "repo_managers", force: true do |t|
+    t.string   "username"
+    t.boolean  "active"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "repo_managers", ["username"], name: "index_repo_managers_on_username", unique: true
 
   create_table "searches", force: true do |t|
     t.text     "query_params"

--- a/spec/models/repo_manager_spec.rb
+++ b/spec/models/repo_manager_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe RepoManager do
+  it { expect(described_class.usernames).to be_a(Enumerable) }
+end


### PR DESCRIPTION
Related to #ndlib/227

@7ae8479db8934ce3ada53fa06c58f8c6195dbcf4

    Adding repo manager tests.

@bf8fbe0d14529a545edfc94ccb43ca8fb0d6008f

    Adding migrations to spec/internal

    Why:

    * The spec/internal is no longer built on the fly but instead has benn
      @ed to the repository.

    This change addresses the need by:

    * cd spec/interal; rake curate_engine:install:migrations

@9d5ffcf048979f23cc0583afc98484505a884edb

    Adding repo_manager routes to Curate engine

    Instead of resources, opting for resource.

@b6860cd56044386839adf54b76317d5a2e693e58

    Tidying up controller

    Removing puts statement and prefering a single query instead of
    a complicated query.

@0be45f91fa580a61ce5b1562e864b522c995e922

    Cleaning up UserBehavior::Base

    Narrowing the method calls and query scopes to be lighter on the DB.
    Instead of getting all records, query directly for that RepoManager
    instance.

@33f43d0a4d211ec64479ea5b0f155dea73102288

    Renaming method to reflect understanding

    I was confused by `is_user_a_manager?`. It appears that we want to
    know if the person is a registered repository manager.

@04c6b9150d919e8608e69c19d635e9218f5fdecc

    Tidying up RepoManager queries

    * RepoManager#active? is a convenience method if there exists a
      database column `repo_managers.active`
    * Validating uniqueness on a record is never guaranteed unless it is
      a database constraint.
    * Adding a database constraint to `repo_managers.active`

@292f8c732d3e6c9c405e865c32027174f3a815d2

    Move repo_manager from yml file to database
