### PR TITLE
Common Objects viewer responds with unauthorized rather than a stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp/*
 .sass-cache
 .idea/
 coverage
+spec/internal/tmp/cache/

--- a/app/controllers/common_objects_controller.rb
+++ b/app/controllers/common_objects_controller.rb
@@ -13,9 +13,15 @@ class CommonObjectsController < ApplicationController
   helper_method :curation_concern
   helper CommonObjectsHelper
 
+  def unauthorized_path
+    'app/views/curation_concern/base/unauthorized'
+  end
+
   before_filter :enforce_show_permissions, only: [:show]
   rescue_from Hydra::AccessDenied do |exception|
-    redirect_to common_object_stub_information_path(curation_concern)
+    respond_with curation_concern do |format|
+      format.html { render unauthorized_path, status: 401 }
+    end
   end
 
   def show

--- a/spec/controllers/common_objects_controller_spec.rb
+++ b/spec/controllers/common_objects_controller_spec.rb
@@ -11,6 +11,8 @@ describe CommonObjectsController do
   }
   describe '#show' do
     let(:template_for_success) { 'show' }
+    let(:template_for_restricted_object) { 'layouts/common_objects' }
+
     describe '"Open Access" object' do
       let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
       it 'renders for unauthenticated person' do
@@ -38,8 +40,8 @@ describe CommonObjectsController do
       let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
       it 'redirect for unauthenticated person' do
         get :show, id: curation_concern.to_param
-        response.status.should == 302
-        expect(response).to redirect_to(common_object_stub_information_path(curation_concern))
+        response.status.should == 401
+        expect(response).to render_template(template_for_restricted_object)
       end
 
       it 'renders for the creator' do
@@ -52,16 +54,17 @@ describe CommonObjectsController do
       it 'renders for the creator' do
         sign_in(another_user)
         get :show, id: curation_concern.to_param
-        response.status.should == 302
-        expect(response).to redirect_to(common_object_stub_information_path(curation_concern))
+        response.status.should == 401
+        expect(response).to render_template(template_for_restricted_object)
       end
     end
+
     describe '"Institution Only" object' do
       let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
       it 'does not display for unauthenticated person' do
         get :show, id: curation_concern.to_param
-        response.status.should == 302
-        expect(response).to redirect_to(common_object_stub_information_path(curation_concern))
+        response.status.should == 401
+        expect(response).to render_template(template_for_restricted_object)
       end
 
       it 'renders for the creator' do

--- a/spec/internal/app/views/curation_concern/base/unauthorized.html.erb
+++ b/spec/internal/app/views/curation_concern/base/unauthorized.html.erb
@@ -1,0 +1,3 @@
+<h1>Unauthorized</h1>
+<p>The <%= curation_concern.human_readable_type.downcase %> you have tried to access is private<p>
+<p>ID: <%= curation_concern.id %>


### PR DESCRIPTION
Redirecting unauthorized users to a stub page is awkward because if a user logs in to try to gain access they will be redirected back to the stub page.