### PR TITLE
Removing requirement for an advisor

### DIFF
--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -79,8 +79,7 @@ class Etd < ActiveFedora::Base
     ds.attribute :advisor,
       label: "Advisor",
       hint: "Advisor(s) to the thesis author.",
-      multiple: true,
-      validates: { presence: { message: "Your #{etd_label} must have an advisor." } }
+      multiple: true
     ds.attribute :date_created,
       label: "Date",
       hint: "The date that appears on the title page or equivalent of the #{etd_label}.",


### PR DESCRIPTION
For the legacy ingest we mapped the advisors to both contributor and
advisor; Since contributor allows for a stated role, this is a superior
solution.

For Sipity ingests we mapped the contributors (Committee Member) to the
contributor attribute