### PR TITLE
Submitting an ETD without an date_uploaded throws an error

### DIFF
--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -85,7 +85,7 @@ class Etd < ActiveFedora::Base
       hint: "The date that appears on the title page or equivalent of the #{etd_label}.",
       multiple: false
     ds.attribute :date_uploaded,
-      default: Date.today.to_s("%Y-%m-%d"),
+      default: lambda { Date.today.to_s("%Y-%m-%d") },
       multiple: false,
       validates: { presence: { message: "You must enter the date uploaded for your #{etd_label}." } }
     ds.attribute :date_modified,
@@ -125,7 +125,7 @@ class Etd < ActiveFedora::Base
     ds.attribute :urn,
       multiple: false
     ds.attribute :date,
-      default: Date.today.to_s("%Y-%m-%d"),
+      default: lambda { Date.today.to_s("%Y-%m-%d") },
       multiple: false,
       label: "Defense Date",
       validates: { presence: { message: "Your #{etd_label} must have a defense date." } }

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -13,7 +13,7 @@ class Etd < ActiveFedora::Base
 
   include CurationConcern::RemotelyIdentifiedByDoi::Attributes
 
-  etd_label = human_readable_type.downcase
+  etd_label = human_readable_type
 
   class_attribute :human_readable_short_description
   self.human_readable_short_description = "Deposit a senior thesis, master's thesis, or dissertation."
@@ -85,8 +85,10 @@ class Etd < ActiveFedora::Base
       hint: "The date that appears on the title page or equivalent of the #{etd_label}.",
       multiple: false
     ds.attribute :date_uploaded,
-      multiple: false
-    ds.attribute :date_modified, 
+      default: Date.today.to_s("%Y-%m-%d"),
+      multiple: false,
+      validates: { presence: { message: "You must enter the date uploaded for your #{etd_label}." } }
+    ds.attribute :date_modified,
       multiple: false
     ds.attribute :subject,
       label: "Subject",

--- a/spec/repository_models/etd_spec.rb
+++ b/spec/repository_models/etd_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Etd do
   subject { FactoryGirl.build(:etd) }
 
-  #it_behaves_like 'with_related_works'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_common_solr_fields'
 
@@ -51,5 +50,4 @@ describe Etd do
   subject { Etd.new }
 
   it_behaves_like 'with_access_rights'
-
 end


### PR DESCRIPTION
Leaving the “Submission Date” (label for :date_uploaded) of an ETD blank when creating a new record causes ActiveFedora to throw an 'invalid date' error.

I required the field and added a default value to get things moving again.